### PR TITLE
Fixed WebView plugin, updated to newest version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.11.3+13
-  flutter_webview_plugin: ">=0.0.5 <0.1.0"
+  flutter_webview_plugin: ^0.1.6
 
 dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
Currently, Flutter throws an error about expecting Future<dynamic>, but receiving Future<Null>. This fixed the error from occurring, but did not show me the WebView plugin (Which is likely my inexperience with API's)